### PR TITLE
Enable streaming the pose of the realsense as TF transform in ROS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ A tool for estimating the [iCubHeadCenter](https://robotology.github.io/robotolo
 - [icub-contrib-common](https://github.com/robotology/icub-contrib-common)
 - [ViSP](https://visp.inria.fr/install/)
 
+## Run-time dependencies
+- [yarp-devices-ros](https://github.com/robotology/yarp-devices-ros)
+> If you need to stream the transform between the robot root frame and the camera frame as a TF transform in ROS, the devices from the above repositories should be part of your YARP installation. If streaming to ROS is not required, it is not required to install them.
+
 ## How to build
 
 ```console
@@ -63,6 +67,11 @@ Please check the intrinsic parameters of your camera, and eventually change them
    - the desired update period of the module
    - the eye version of the robot
    - (optional) the absolute path to the calibration matrix file (produced by the module `realsense-holder-calibration`)
+
+   Additionally, the following parameters are also available:
+   - the `use_ros` parameter which enable/disables streaming to ROS as a TF transform
+   - the `ros_src_frame_id` that decides the parent id of the TF transform
+   - the `ros_dest_frame_id` that decides the child id of the TF transform
 
 If the path of the calibration matrix file is not provided, the module will search for it in `.local/share/yarp/context/realsense-holder-publisher/eMc.txt`.
 
@@ -144,9 +153,12 @@ Variant tilt
 2. Open the `yarpmanager`
 3. Open the `Eye-hand_calibration publisher` application
 4. Specify the desired configuration file in the parameters using `--from <nome_of_config_file>` if any
+   > if ROS is enabled with the option `use_ros`, it is required to run the `yarpserver` with the `--ros` option and a running instance of `roscore`
 5. Run `realsense-holder-publisher`
 
 The pose of the camera will be available from `/realsense-holder-publisher/pose:o` as a list of `<x> <y> <z> <axis_x> <axis_y> <axis_z> <angle>` numbers where `<x>`, `<y>` and `<z>` are the 3D coordinates of the camera in the robot root frame, while the `<axis_?>` and `<angle>` are the axis/angle representation of the rotation matrix from the robot root frame to the camera reference frame.
+
+If ROS is enabled, the pose will be streamed as a TF transform between the frames `ros_src_frame_id` and `ros_dst_frame_id`.
 
 
 ### Maintainers

--- a/src/publisher/CMakeLists.txt
+++ b/src/publisher/CMakeLists.txt
@@ -16,8 +16,10 @@ find_package(YARP REQUIRED COMPONENTS os sig)
 add_executable(${TARGET_NAME}
                src/main.cpp
                include/Publisher.h
+               include/PublisherRos.h
                include/PublisherYarp.h
                src/Publisher.cpp
+               src/PublisherRos.cpp
                src/PublisherYarp.cpp
 )
 

--- a/src/publisher/CMakeLists.txt
+++ b/src/publisher/CMakeLists.txt
@@ -16,7 +16,9 @@ find_package(YARP REQUIRED COMPONENTS os sig)
 add_executable(${TARGET_NAME}
                src/main.cpp
                include/Publisher.h
+               include/PublisherYarp.h
                src/Publisher.cpp
+               src/PublisherYarp.cpp
 )
 
 target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include ${VISP_INCLUDE_DIRS})

--- a/src/publisher/app/conf/config.ini
+++ b/src/publisher/app/conf/config.ini
@@ -1,4 +1,7 @@
 robot_name             icub
 eye_version            v2
 period                 0.01
+use_ros                false
+ros_src_frame_id       icub_root
+ros_dst_frame_id       icub_realsense
 #calibration_file_path

--- a/src/publisher/include/Publisher.h
+++ b/src/publisher/include/Publisher.h
@@ -15,6 +15,7 @@
 #include <yarp/sig/Matrix.h>
 
 #include <ForwardKinematics.h>
+#include <PublisherRos.h>
 #include <PublisherYarp.h>
 
 
@@ -40,6 +41,10 @@ private:
 
     /* Output via YARP. */
     std::unique_ptr<PublisherYarp> output_yarp_;
+
+    /* Output via ROS (optional). */
+    bool publish_ros_;
+    std::unique_ptr<PublisherRos> output_ros_;
 
     /* Period. */
     double period_;

--- a/src/publisher/include/Publisher.h
+++ b/src/publisher/include/Publisher.h
@@ -9,13 +9,13 @@
 #ifndef PUBLISHER_H
 #define PUBLISHER_H
 
-#include <yarp/os/BufferedPort.h>
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/RFModule.h>
 
 #include <yarp/sig/Matrix.h>
 
 #include <ForwardKinematics.h>
+#include <PublisherYarp.h>
 
 
 class Publisher : public yarp::os::RFModule
@@ -38,8 +38,8 @@ private:
     /* iCub forward kinematics. */
     std::unique_ptr<ForwardKinematics> fk_;
 
-    /* Output port. */
-    yarp::os::BufferedPort<yarp::sig::Vector> port_output_;
+    /* Output via YARP. */
+    std::unique_ptr<PublisherYarp> output_yarp_;
 
     /* Period. */
     double period_;

--- a/src/publisher/include/PublisherRos.h
+++ b/src/publisher/include/PublisherRos.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021-2023 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef PUBLISHER_ROS_H
+#define PUBLISHER_ROS_H
+
+#include <yarp/dev/IFrameTransformStorage.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/math/FrameTransform.h>
+#include <yarp/os/Stamp.h>
+#include <yarp/sig/Matrix.h>
+#include <yarp/sig/Vector.h>
+
+
+class PublisherRos
+{
+public:
+
+    PublisherRos(const std::string& node_name, const std::string& source_frame_id, const std::string& destination_frame_id);
+
+    ~PublisherRos();
+
+    void set_transform(const yarp::sig::Matrix& transform);
+
+private:
+    /* PolyDriver . */
+    yarp::dev::PolyDriver driver_;
+
+    /* IFrameTransformStorageSet interface. */
+    yarp::dev::IFrameTransformStorageSet* transform_setter_;
+
+    /* Storage for the transform. */
+    yarp::math::FrameTransform transform_;
+
+    /* Storage for the time stamp. */
+    yarp::os::Stamp stamp_;
+
+    /* Name to be used in messages. */
+    const std::string log_name_ = "PublisherRos";
+};
+
+#endif /* PUBLISHER_ROS_H */

--- a/src/publisher/include/PublisherYarp.h
+++ b/src/publisher/include/PublisherYarp.h
@@ -1,0 +1,36 @@
+
+/*
+ * Copyright (C) 2021-2023 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef PUBLISHER_YARP_H
+#define PUBLISHER_YARP_H
+
+#include <yarp/os/BufferedPort.h>
+
+#include <yarp/sig/Matrix.h>
+#include <yarp/sig/Vector.h>
+
+
+class PublisherYarp
+{
+public:
+
+    PublisherYarp(const std::string& port_name);
+
+    ~PublisherYarp();
+
+    void set_transform(const yarp::sig::Matrix& transform);
+
+private:
+    /* Output port. */
+    yarp::os::BufferedPort<yarp::sig::Vector> port_output_;
+
+    /* Name to be used in messages. */
+    const std::string log_name_ = "PublisherYarp";
+};
+
+#endif /* PUBLISHER_YARP_H */

--- a/src/publisher/src/PublisherRos.cpp
+++ b/src/publisher/src/PublisherRos.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2021-2023 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ */
+
+#include <PublisherRos.h>
+
+#include <yarp/os/Property.h>
+
+using namespace yarp::os;
+
+
+PublisherRos::PublisherRos(const std::string& node_name, const std::string& source_frame_id, const std::string& destination_frame_id)
+{
+    /* Configure the transform setter device. */
+    Property device_properties;
+    device_properties.put("device", "frameTransformSet_nwc_ros");
+
+    Property general_properties;
+    general_properties.put("period", 1.0 / 100.0);
+    general_properties.put("asynch_pub", 0);
+
+    Property ros_properties;
+    ros_properties.put("ft_node", "/" + node_name);
+
+    device_properties.addGroup("GENERAL") = general_properties;
+    device_properties.addGroup("ROS") = ros_properties;
+
+    bool outcome = true;
+    outcome &= driver_.open(device_properties);
+    if (!outcome)
+        throw(std::runtime_error(log_name_ + "::ctor(). Error: cannot open the polydriver."));
+
+    outcome &= driver_.view(transform_setter_);
+    if (!outcome)
+        throw(std::runtime_error(log_name_ + "::ctor(). Error: cannot open the IFrameTransformStorageSet view."));
+
+    /* Configure the source and destination frames for the transform. */
+    transform_.src_frame_id = source_frame_id;
+    transform_.dst_frame_id = destination_frame_id;
+}
+
+
+PublisherRos::~PublisherRos()
+{
+    if (driver_.isValid())
+        driver_.close();
+}
+
+
+void PublisherRos::set_transform(const yarp::sig::Matrix& transform)
+{
+    /* Update the transform. */
+    transform_.fromMatrix(transform);
+
+    /* Update time stamp. */
+    stamp_.update();
+    transform_.timestamp = stamp_.getTime();
+
+    /* Set the transform. */
+    transform_setter_->setTransform(transform_);
+}

--- a/src/publisher/src/PublisherYarp.cpp
+++ b/src/publisher/src/PublisherYarp.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021-2023 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * GPL-2+ license. See the accompanying LICENSE file for details.
+ */
+
+#include <PublisherYarp.h>
+
+#include <yarp/math/Math.h>
+
+using namespace yarp::math;
+using namespace yarp::sig;
+
+
+PublisherYarp::PublisherYarp(const std::string& port_name)
+{
+    /* Open output port. */
+    if(!port_output_.open(port_name))
+        throw(std::runtime_error(log_name_ + "::ctor(). Error: cannot open the output port."));
+}
+
+PublisherYarp::~PublisherYarp()
+{
+    /* Close output port if open. */
+    if (!port_output_.isClosed())
+        port_output_.close();
+}
+
+
+void PublisherYarp::set_transform(const yarp::sig::Matrix& transform)
+{
+    /* Send to port. */
+    Vector axis_angle = dcm2axis(transform.submatrix(0, 2, 0, 2));
+
+    Vector& pose = port_output_.prepare();
+    pose.resize(7);
+    pose(0) = transform(0, 3);
+    pose(1) = transform(1, 3);
+    pose(2) = transform(2, 3);
+    pose(3) = axis_angle(0);
+    pose(4) = axis_angle(1);
+    pose(5) = axis_angle(2);
+    pose(6) = axis_angle(3);
+
+    port_output_.write();
+}


### PR DESCRIPTION
This PR extends the `realsense-holder-publisher` executable such that it can stream the transform of the camera frame with respect to the robot frame as a TF frame in ROS. The behavior is optional and can be enabled from the provided configuration file.

The code has been revised such that publishing in YARP and ROS is achieved via two different classes `PublisherYarp` and `PublisherROS`.

The `README.md` has been updated in order to handle additional run-time dependencies, namely the `frameTransformSet_nwc_ros` device from [yarp-devices-ros](https://github.com/robotology/yarp-devices-ros), and describe the new parameters of the template configuration file.