### PR TITLE
Transition from frameTransformSet_nwc_ros to frameTransformSet_nwc_ros2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ A tool for estimating the [iCubHeadCenter](https://robotology.github.io/robotolo
 - [ViSP](https://visp.inria.fr/install/)
 
 ## Run-time dependencies
-- [yarp-devices-ros](https://github.com/robotology/yarp-devices-ros)
-> If you need to stream the transform between the robot root frame and the camera frame as a TF transform in ROS, the devices from the above repositories should be part of your YARP installation. If streaming to ROS is not required, it is not required to install them.
+- [yarp-devices-ros2](https://github.com/robotology/yarp-devices-ros2)
+> If you need to stream the transform between the robot root frame and the camera frame as a TF transform in `ROS 2`, the devices from the above repositories should be part of your YARP installation. If streaming to `ROS 2` is not required, it is not required to install them.
 
 ## How to build
 

--- a/src/publisher/app/conf/config.ini
+++ b/src/publisher/app/conf/config.ini
@@ -1,7 +1,7 @@
 robot_name             icub
 eye_version            v2
 period                 0.01
-use_ros                false
+use_ros2               false
 ros_src_frame_id       icub_root
 ros_dst_frame_id       icub_realsense
 #calibration_file_path

--- a/src/publisher/src/Publisher.cpp
+++ b/src/publisher/src/Publisher.cpp
@@ -30,8 +30,8 @@ bool Publisher::configure(ResourceFinder &rf)
     /* Get the period in seconds. */
     period_ = rf.check("period", Value(0.01)).asFloat64();
 
-    /* Get the optional ROS publishing flag. */
-    publish_ros_ = rf.check("use_ros", Value(false)).asBool();
+    /* Get the optional ROS 2 publishing flag. */
+    publish_ros_ = rf.check("use_ros2", Value(false)).asBool();
     std::string src_frame_id;
     std::string dst_frame_id;
     if (publish_ros_)

--- a/src/publisher/src/PublisherRos.cpp
+++ b/src/publisher/src/PublisherRos.cpp
@@ -16,17 +16,17 @@ PublisherRos::PublisherRos(const std::string& node_name, const std::string& sour
 {
     /* Configure the transform setter device. */
     Property device_properties;
-    device_properties.put("device", "frameTransformSet_nwc_ros");
+    device_properties.put("device", "frameTransformSet_nwc_ros2");
 
     Property general_properties;
     general_properties.put("period", 1.0 / 100.0);
     general_properties.put("asynch_pub", 0);
 
     Property ros_properties;
-    ros_properties.put("ft_node", "/" + node_name);
+    ros_properties.put("ft_node", node_name);
 
     device_properties.addGroup("GENERAL") = general_properties;
-    device_properties.addGroup("ROS") = ros_properties;
+    device_properties.addGroup("ROS2") = ros_properties;
 
     bool outcome = true;
     outcome &= driver_.open(device_properties);


### PR DESCRIPTION
Back in #2, we have implemented the possibility to stream the camera pose on TF using ROS. This was done using the not-mainted-anymore `yarp-devices-ros`. This PR provides the same functionality using ROS2, again via YARP and the brand new `yarp-devices-ros2`. At the same time it removes support for ROS.

The previous feature was implemented only for testing purposes and it is not used nowhere. Thus, it is safe to completely remove it.