### PR TITLE
Enforce transform publishing rate when using ROS 2

### DIFF
--- a/src/publisher/src/PublisherRos.cpp
+++ b/src/publisher/src/PublisherRos.cpp
@@ -19,8 +19,10 @@ PublisherRos::PublisherRos(const std::string& node_name, const std::string& sour
     device_properties.put("device", "frameTransformSet_nwc_ros2");
 
     Property general_properties;
-    general_properties.put("period", 1.0 / 100.0);
-    general_properties.put("asynch_pub", 0);
+    /* Run the thread at 1 Hz as the transform publishing will be driven by the thread calling this::setTransform(). */
+    general_properties.put("period", 1.0);
+    general_properties.put("refresh_interval", 0.1);
+    general_properties.put("asynch_pub", 1);
 
     Property ros_properties;
     ros_properties.put("ft_node", node_name);


### PR DESCRIPTION
When publishing via ROS 2 is enabled in `realsense-holder-publisher`, the `frameTransformSet_nwc_ros2` device starts a period thread on its own to publish data on `tf`.  On the other hand, the main module of the `realsense-holder-publisher` node also runs periodically within a `yarp::os::RFModule`. 

In order to enforce as much as possible the update rate of the main module, the ROS 2 device is configured within this PR to use the asynchronous publishing mode - while the period of the inner thread is reduced to 1 Hz.