### PR TITLE
Change references from RGBDSensorWrapper to rgbdSensor_nws_yarp

### DIFF
--- a/src/calibration/app/conf/config_rs.ini
+++ b/src/calibration/app/conf/config_rs.ini
@@ -1,4 +1,4 @@
-device       RGBDSensorWrapper
+device       rgbdSensor_nws_yarp
 subdevice    realsense2
 name         /depthCamera
 


### PR DESCRIPTION
The `RGBDSensorWrapper` device was deprecated in YARP 3.5 and removed in YARP 3.8 (see https://github.com/robotology/yarp/commit/4da405c7fb077b4604029fd87e4e51a633e2d7eb) and it has been substituted by `rgbdSensor_nws_yarp`. Note that the corresponding network wrapper client (`nwc`) device that reads the rgbd data from a YARP port is called `RGBDSensorClient`.

However, there was still config files that was referring to `RGBDSensorWrapper`, this PR fixes those occurrences.

Similar to https://github.com/robotology/yarp/pull/3150 .
